### PR TITLE
Update doxyfile

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -961,21 +961,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = Lab_0/README.md \
-                         Lab_1/README.md \
-                         Lab_2/README.md \
-                         Lab_3/README.md \
-                         Lab_4/README.md \
-                         Lab_5/README.md \
-                         Lab_6/README.md \
-                         Lab_7/README.md \
-                         Lab_8/README.md \
-                         Additional_Labs/Lab_9/README.md  \
-                         Additional_Labs/Lab_10/README.md \
-                         Additional_Labs/Lab_11/README.md \
-                         Additional_Labs/README.md        \
-                         README.md                        \
-                         third-party                      \ #ignore submodules! 
+EXCLUDE                =  third-party \ #ignore submodules! 
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -991,7 +977,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = README.md
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
Update doxyfile by adding EXCLUDE_PATTERNS and removing all README files in EXCLUDE. This allows adding more readme without needing to exclude them manually. Therefore, the doxyfile will always build the latest version of documentation without any additional changes.