### PR TITLE
Added lcd driver submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third-party/doxygen-awesome-css"]
 	path = third-party/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css
+[submodule "third-party/ESP32-LCD-1602-Driver"]
+	path = third-party/ESP32-LCD-1602-Driver
+	url = https://github.com/jminjares4/ESP32-LCD-1602-Driver


### PR DESCRIPTION
- Added custom lcd driver submodule for students to be able to use LCD 16x02
- LCD driver has fully customizable gpio pins
- Ensure low GPIO usage: limited to 6 pins 